### PR TITLE
fix: don't include provider on child module

### DIFF
--- a/modules/provision/provider.tf
+++ b/modules/provision/provider.tf
@@ -1,8 +1,0 @@
-terraform {
-    required_providers {
-        aws = {
-            source  = "hashicorp/aws"
-            version = "5.4.0"
-        }
-    }
-}


### PR DESCRIPTION
I'm attempting to use this Terraform module by making my own "main.tf" file, and then referencing the module in this git repository directly through the use of:

```
source = "github.com/CrowdStrike/aws-cspm-registration-terraform.git//modules/provision?ref=githash"
```

However, as the provider.tf in this module is very outdated and is locked to a specific version, Terraform fails to resolve the version as it conflicts with my version requirement to use the latest version.

As this repository already explicitly specifies the provider version on the parent main.tf files, the modules will implicitly use the same provider as the parent. Therefore, there is no need to have the provider explicitly specified on the module, and removing it will fix my use case.